### PR TITLE
Fix Gene Error if downSet is NULL

### DIFF
--- a/R/generatNullGeneric.R
+++ b/R/generatNullGeneric.R
@@ -135,7 +135,6 @@ function(upSet,
          useBPPARAM = NULL) {
 
   upSet <- GSEABase::GeneSet(as.character(upSet))
-  downSet <- GSEABase::GeneSet(as.character(downSet))
   plt <- generateNull(
     upSet = upSet,
     downSet = downSet,


### PR DESCRIPTION
If the downSet is NULL, you should not try to create a GeneSet with NULL on line 138. That's what causes the error about gene names.